### PR TITLE
Bump the dependency on base to < 4.15 (was < 4.13)

### DIFF
--- a/fadno-xml.cabal
+++ b/fadno-xml.cabal
@@ -30,7 +30,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:       Decimal >= 0.4
-                     , base >= 4.9 && < 4.13
+                     , base >= 4.9 && < 4.15
                      , containers >= 0.5
                      , lens >= 4.15
                      , mtl >= 2.2


### PR DESCRIPTION
GHC 8.8.* uses `base` = 4.13 (July 2019) and GHC 8.10.* uses `base` = 4.14 (January 2020).

The current .cabal file dependency for `base` is < 4.13, so `fadno-xml` will not build on these versions. It is also listed as broken (not compiling) in the set of Nix curated packages, [nixpkgs](https://github.com/NixOS/nixpkgs/blob/54d42c22b7d9f1c3e73a6ac1a9f3a16d2eec2a6e/pkgs/development/haskell-modules/configuration-hackage2nix.yaml).

I have checked that it compiles and runs with GHC 8.8.4, base-4.13.0.0 after the dependency is changed to `base` < 4.14. I haven't really tested it, but the Haskell [base package changelog](https://hackage.haskell.org/package/base-4.14.0.0/changelog) doesn't seem to have any relevant changes, so it should be safe to change.

The packages `fadno` and `fadno-braids` are also listed as broken in nixpkgs and can likely be made to compile in the same way.

